### PR TITLE
Fix stale time defaults and guard optional UI hooks

### DIFF
--- a/js/calculator.js
+++ b/js/calculator.js
@@ -23,8 +23,6 @@ const Calculator = (function() {
             return null;
         }
 
-        localStorage.setItem(`lastTime_${type}`, timeInput.value);
-        
         const baseMins = timeToMinutes(timeInput.value);
         const fallAsleepOffset = settings.includeFallAsleep ? settings.fallAsleepTime : 0;
         // let user override the cycle length, or use the default.


### PR DESCRIPTION
## Summary
- ensure the "sleep now" input defaults to the current time unless a recently saved value exists and persist timestamps for stored entries
- remember calculation inputs after successful runs and tolerate legacy stored strings without breaking existing users
- guard optional UI hooks so secondary pages without calculator elements no longer trigger runtime errors

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e60b616830832c85a069ecc2707f70