### PR TITLE
Center settings dropdown menu on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -101,4 +101,11 @@ body {
     }
     .main-container { margin: 0.5rem; }
     .card-body { padding: 1.5rem !important; }
+    #settings-controls .dropdown-menu,
+    #settings-controls-science .dropdown-menu {
+        left: 50% !important;
+        transform: translateX(-50%);
+        right: auto !important;
+        width: min(90vw, 320px);
+    }
 }


### PR DESCRIPTION
## Summary
- center align the settings dropdown on small screens so the menu no longer overflows off screen
- limit the dropdown width on mobile to fit within the viewport

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e60f9a1340832c9325a8c85a78d992